### PR TITLE
v2.2 - OP-4645: Update AWS codebuild project TF module to version 2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Creates a pipeline that builds a container via codebuild and pushes it to an ECR
 
 ```hcl
 module "ecr_pipeline" {
-  source = "github.com/globeandmail/aws-codepipeline-ecr?ref=2.1"
+  source = "github.com/globeandmail/aws-codepipeline-ecr?ref=2.2"
 
   name               = app-name
   ecr_name           = repo-name
@@ -83,6 +83,8 @@ You can add these 8 lines to the end of your `build` phase commands in `buildspe
       - echo "Running Sysdig image cli scan..."
       - SECURE_API_TOKEN=${SYSDIG_API_TOKEN_SECRETS_ID} ./sysdig-cli-scanner --apiurl https://us2.app.sysdig.com ${REPOSITORY_URI}:${IMAGE_TAG} --policy sysdig_best_practices || true
 ```
+## v.2.2 Note
+The `aws-codebuild-project` version is upgraded to version `2.2` to override AWS S3 bucket default ACL setting. The AWS S3 security changes can be found in the AWS blog [here](https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/)
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ You can add these 8 lines to the end of your `build` phase commands in `buildspe
       - SECURE_API_TOKEN=${SYSDIG_API_TOKEN_SECRETS_ID} ./sysdig-cli-scanner --apiurl https://us2.app.sysdig.com ${REPOSITORY_URI}:${IMAGE_TAG} --policy sysdig_best_practices || true
 ```
 ## v.2.2 Note
-The `aws-codebuild-project` version is upgraded to version `2.2` to override AWS S3 bucket default ACL setting. The AWS S3 security changes can be found in the AWS blog [here](https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/)
+The `aws-codebuild-project` version is upgraded to version `2.2` to override AWS S3 bucket default ACL setting. The AWS S3 security changes can be found in the AWS blog [here](https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/).
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -57,7 +57,7 @@ resource "aws_iam_role_policy" "codepipeline_baseline" {
 }
 
 module "codebuild_project" {
-  source = "github.com/globeandmail/aws-codebuild-project?ref=2.1"
+  source = "github.com/Mather-Sophi/aws-codebuild-project?ref=2.2"
 
   name                                         = var.name
   deploy_type                                  = "ecr"


### PR DESCRIPTION
#### PR description

What is it for?
The PR is to update the TF module aws-codebuild-project to version 2.2 and update its input variables. 
The change is needed to to fix the error encountered while running Terraform apply command. Stack Overflow post:
https://stackoverflow.com/questions/76049290/error-accesscontrollistnotsupported-when-trying-to-create-a-bucket-acl-in-aws.

#### Testing instructions

- Verify TF apply command error is resolved.

#### JIRA ticket information

Story: [OP-4645](https://jira.theglobeandmail.com/browse/OP-4645)

[OP-4645]: https://mathereconomics.atlassian.net/browse/OP-4645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ