### PR TITLE
v2.2 - OP-4645: Add build_compute_type TF variable for AWS CodeBuild TF module

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ The `aws-codebuild-project` version is upgraded to version `2.2` to override AWS
 | github\_branch\_name | The git branch name to use for the codebuild project | string | `"master"` | no |
 | buildspec | The name of the buildspec file to use | string | buildspec.yml | no |
 | codebuild\_image | The codebuild image to use | string | `"null"` | no |
+| build\_compute\_type | Build environment compute type | string | `"null"` | no |
 | tags | A mapping of tags to assign to the resource | map | `{}` | no |
 | use\_repo\_access\_github\_token | \(Optional\) Allow the AWS codebuild IAM role read access to the REPO\_ACCESS\_GITHUB\_TOKEN secrets manager secret in the shared service account.<br>Defaults to false. | `bool` | `false` | no |
 | svcs\_account\_github\_token\_aws\_secret\_arn | \(Optional\) The AWS secret ARN for the repo access Github token.<br>The secret is created in the shared service account.<br>Required if var.use\_repo\_access\_github\_token is true. | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -64,6 +64,7 @@ module "codebuild_project" {
   ecr_name                                     = var.ecr_name
   buildspec                                    = var.buildspec
   use_docker_credentials                       = var.use_docker_credentials
+  build_compute_type                           = var.build_compute_type
   tags                                         = var.tags
   use_repo_access_github_token                 = var.use_repo_access_github_token
   svcs_account_github_token_aws_secret_arn     = var.svcs_account_github_token_aws_secret_arn

--- a/variables.tf
+++ b/variables.tf
@@ -41,6 +41,12 @@ variable "codebuild_image" {
   default     = null
 }
 
+variable "build_compute_type" {
+  type        = string
+  description = "(Optional) build environment compute type"
+  default     = "BUILD_GENERAL1_SMALL"
+}
+
 variable "use_docker_credentials" {
   type        = bool
   description = "(Optional) Use dockerhub credentals stored in parameter store"


### PR DESCRIPTION
#### PR description

What is it for?
Add `build_compute_type` TF variable for AWS CodeBuild TF module.

#### Testing instructions

- Verify the ECR CodePipeline TF module can be applied successfully from other TF templates.

#### JIRA ticket information

Story: [OP-4645](https://jira.theglobeandmail.com/browse/OP-4645)

[OP-4645]: https://mathereconomics.atlassian.net/browse/OP-4645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ